### PR TITLE
feat: Dropped DHCPv6 method

### DIFF
--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -50,7 +50,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
     private static final String STATUS_LAN = "netIPv6StatusEnabledLAN";
     private static final String STATUS_WAN = "netIPv6StatusEnabledWAN";
     private static final String CONFIGURE_AUTO = "netIPv6MethodAuto";
-    private static final String CONFIGURE_DHCP = "netIPv6MethodDhcp";
     private static final String CONFIGURE_MANUAL = "netIPv6MethodManual";
     private static final String AUTOCONF_EUI64 = "netIPv6AddressGenModeEUI64";
     private static final String AUTOCONF_STABLEPRIVACY = "netIPv6AddressGenModeStablePrivacy";
@@ -248,7 +247,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
 
     private void initConfigureField() {
         this.configure.addItem(MessageUtils.get(CONFIGURE_AUTO), CONFIGURE_AUTO);
-        this.configure.addItem(MessageUtils.get(CONFIGURE_DHCP), CONFIGURE_DHCP);
         this.configure.addItem(MessageUtils.get(CONFIGURE_MANUAL), CONFIGURE_MANUAL);
 
         this.configure.addMouseOverHandler(event -> {
@@ -560,15 +558,13 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             this.dns.setText("");
         }
 
-        if (this.configure.getSelectedValue().equals(CONFIGURE_AUTO)
-                || this.configure.getSelectedValue().equals(CONFIGURE_DHCP)) {
+        if (this.configure.getSelectedValue().equals(CONFIGURE_AUTO)) {
             this.ip.setEnabled(false);
             this.subnet.setEnabled(false);
             this.gateway.setEnabled(false);
         }
 
-        if (this.configure.getSelectedValue().equals(CONFIGURE_MANUAL)
-                || this.configure.getSelectedValue().equals(CONFIGURE_DHCP)) {
+        if (this.configure.getSelectedValue().equals(CONFIGURE_MANUAL)) {
             this.autoconfiguration.setEnabled(false);
             this.privacy.setEnabled(false);
         }

--- a/bundles/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/ValidationMessages.properties
+++ b/bundles/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/ValidationMessages.properties
@@ -116,8 +116,7 @@ netIPv6StatusDisabled=Disabled
 netIPv6StatusEnabledLAN=Enabled for LAN
 netIPv6StatusEnabledWAN=Enabled for WAN
 
-netIPv6MethodAuto=Stateless Address Auto-Configuration (SLAAC)
-netIPv6MethodDhcp=Using DHCPv6
+netIPv6MethodAuto=Auto
 netIPv6MethodManual=Manually
 
 netIPv6AddressGenModeEUI64=EUI64


### PR DESCRIPTION
This pull request simplifies the IPv6 configuration options in the network UI by removing the DHCPv6 method, both from the backend logic and the user interface. The changes focus on cleaning up configuration options and updating related UI behaviors and messages.

**IPv6 Configuration Option Cleanup:**

* Removed the `CONFIGURE_DHCP` constant and all references to the DHCPv6 configuration method from `TabIp6Ui.java`, including the UI dropdown and logic handling. [[1]](diffhunk://#diff-10fc5033a8ac61576f3780165ede4822c67fb72e876c0931184c0d54f0e0d23bL53) [[2]](diffhunk://#diff-10fc5033a8ac61576f3780165ede4822c67fb72e876c0931184c0d54f0e0d23bL251) [[3]](diffhunk://#diff-10fc5033a8ac61576f3780165ede4822c67fb72e876c0931184c0d54f0e0d23bL563-R567)
* Updated the user-facing label for the auto-configuration method from "Stateless Address Auto-Configuration (SLAAC)" to simply "Auto" in the properties file.