### PR TITLE
fix(ui): NPE on notEqualsIdentityName password validators

### DIFF
--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
@@ -192,7 +192,6 @@ public class Picker extends Composite implements HasId {
 
             Picker.this.inputPanel.add(input);
 
-            input.validate();
             input.reset();
             Picker.this.modal.show();
         }

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/GwtValidators.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/GwtValidators.java
@@ -98,7 +98,13 @@ public class GwtValidators {
     }
 
     public static Validator<String> notEqualsIdentityName(final String identityName, final String message) {
-        return new ValidatorWrapper<>(new PredicateValidator(v -> !v.equalsIgnoreCase(identityName), message), Priority.MEDIUM);
+        return new ValidatorWrapper<>(new PredicateValidator(v -> {
+            if (v == null) {
+                return true;
+            }
+
+            return !v.equalsIgnoreCase(identityName);
+        }, message), Priority.MEDIUM);
     }
 
     public static <T> Validator<T> notInList(final List<T> values, final String message) {

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/validator/PasswordStrengthValidators.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/validator/PasswordStrengthValidators.java
@@ -90,7 +90,13 @@ public class PasswordStrengthValidators {
     private static Validator<String> requireDifferentNameAndPassword(final String identityName,
             final Messages messages) {
 
-        return new PredicateValidator(v -> !v.equalsIgnoreCase(identityName), messages.pwdNotEqualsUsername());
+        return new PredicateValidator(v -> {
+            if (v == null) {
+                return true;
+            }
+
+            return !v.equalsIgnoreCase(identityName);
+        }, messages.pwdNotEqualsUsername());
     }
 
     public interface Messages {


### PR DESCRIPTION
This PR fixes some null pointer exceptions that arise when the input has just been created and is null

<img width="1024" height="711" alt="image" src="https://github.com/user-attachments/assets/54132aaf-f5e3-47d9-87e3-a7f2973f28ff" />
