### PR TITLE
fix: incorrectly closing download/rollback snapshot modal

### DIFF
--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotSelectorModal.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotSelectorModal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -113,6 +113,8 @@ public abstract class SnapshotSelectorModal extends Composite {
         this.advancedConfirmationAlert.setVisible(false);
 
         this.snapshotForm.add(this.requestXsrfToken);
+
+        this.snapshotModal.addHideHandler(event -> this.snapshotFooter.clear());
     }
 
     /*


### PR DESCRIPTION
The snapshot download/rollback modal can be closed by pressing the `esc` button after interacting with one of the item (checkbox, textbox and so on). When this happened, the modal was closed bypassing our direct control: this prevented the cleaning of the modal, in particular the modal footer.

After reopening, it presented multiples of 3 (download) or 2 (rollback) buttons, because each time the modal was closed with `esc` the buttons were not cleared; opening again the modal triggered again the button generation, leading to a large number of the same buttons shown (most of them not even clickable):
<img width="1072" height="885" alt="image" src="https://github.com/user-attachments/assets/70ff0335-c598-4108-9f63-1f2dbd63048b" />

This PR fixes the problem, overwriting the standard `hide()` method of the modal, forcing the cleaning each time the modal is closed, whatever is the caller of the hiding.
