### PR TITLE
fix: missing buttons when canceling advanced snapshot rollback

### DIFF
--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotRollbackModal.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotRollbackModal.java
@@ -46,15 +46,7 @@ public class SnapshotRollbackModal extends SnapshotSelectorModal {
 
         clearClickHandlers();
 
-        this.cancelButton = new SnapshotSelectorActionButton(MSGS.cancelButton(), FONT_AWESOME_STYLE_NAME,
-                ButtonType.PRIMARY, e -> hideAndReset());
-
-        this.rollbackOrNextButton = new SnapshotSelectorActionButton(MSGS.rollback(), FONT_AWESOME_STYLE_NAME,
-                ButtonType.PRIMARY,
-                e -> onRollbackOrNextClick(getSelectedSnapshot(), getSelectedPidsList(), getAdvancedModeValue()));
-
-        addFooterButton(this.cancelButton);
-        addFooterButton(this.rollbackOrNextButton);
+        setupFooterButtons();
 
         setModalTitleDescriptionAndHints(MSGS.deviceSnapshotRollbackTitle(), MSGS.deviceSnapshotRollbackConfirm(),
                 MSGS.deviceSnapshotRollbackHint());
@@ -62,6 +54,16 @@ public class SnapshotRollbackModal extends SnapshotSelectorModal {
         setAdvancedModePanelVisible(true);
 
         setAdvancedModeClickHandler(this::onAdvancedModeClick);
+    }
+
+    @Override
+    protected void recoverAndShowMainModal() {
+        
+        this.snapshotFooter.clear();
+        
+        setupFooterButtons();
+
+        super.recoverAndShowMainModal(); // o this.snapshotModal.show()
     }
 
     /*
@@ -192,5 +194,17 @@ public class SnapshotRollbackModal extends SnapshotSelectorModal {
             this.advancedModeClickHandler.removeHandler();
         }
 
+    }
+
+    private void setupFooterButtons() {
+        this.cancelButton = new SnapshotSelectorActionButton(MSGS.cancelButton(), FONT_AWESOME_STYLE_NAME,
+                ButtonType.PRIMARY, e -> hideAndReset());
+
+        this.rollbackOrNextButton = new SnapshotSelectorActionButton(MSGS.rollback(), FONT_AWESOME_STYLE_NAME,
+                ButtonType.PRIMARY,
+                e -> onRollbackOrNextClick(getSelectedSnapshot(), getSelectedPidsList(), getAdvancedModeValue()));
+
+        addFooterButton(this.cancelButton);
+        addFooterButton(this.rollbackOrNextButton);
     }
 }

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotSelectorModal.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotSelectorModal.java
@@ -173,10 +173,10 @@ public abstract class SnapshotSelectorModal extends Composite {
 
     /*
      * Use it to show again the modal without resetting it. It can be used when the user does not confirm the advanced
-     * mode confirmation alert to recover the modal previously hidden.
+     * mode confirmation alert to recover the modal previously hidden. Should be overriden if needed.
      */
 
-    public void recoverAndShowMainModal() {
+    protected void recoverAndShowMainModal() {
         this.snapshotModal.show();
     }
 


### PR DESCRIPTION
When performing an advanced rollback the steps are:

1. Select the Snapshot from Settings tab and click on Rollback
2. Check the Advanced Rollback checkbox and click on Next
3. Confirm the alert dialog

In the third step the user could click on cancel to get back to the pids selector modal: doing this a bug occured and the buttons to Cancel or Rollback/Next were not shown anymore
<img width="602" height="764" alt="Schermata del 2026-01-26 10-57-28" src="https://github.com/user-attachments/assets/d027ed7b-b27e-4d63-b623-81c2d3ede3c5" />

This PR fixes the problem