### PR TITLE
feat: added show/hide button for all password in framework

### DIFF
--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -390,7 +390,6 @@ public abstract class AbstractServicesUi extends Composite {
         }
 
         final NewPasswordInputForm input = new NewPasswordInputForm();
-        input.setInputPasswordText(param.getValue());
         input.setShowPasswordButtonEnabled(!PLACEHOLDER.equals(input.getInputPasswordText()));
         input.setInputPasswordClickHandler(handler -> {
             if (input.isInputPasswordEnabled()

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -390,7 +390,15 @@ public abstract class AbstractServicesUi extends Composite {
         }
 
         final NewPasswordInputForm input = new NewPasswordInputForm();
+
+        if (param.getValue() != null) {
+            input.setInputPasswordText(param.getValue());
+        } else {
+            input.setInputPasswordText("");
+        }
+        
         input.setShowPasswordButtonEnabled(!PLACEHOLDER.equals(input.getInputPasswordText()));
+        
         input.setInputPasswordClickHandler(handler -> {
             if (input.isInputPasswordEnabled()
                     && input.getInputPasswordText().equals(PLACEHOLDER)) {
@@ -399,11 +407,6 @@ public abstract class AbstractServicesUi extends Composite {
                 input.setShowPasswordButtonEnabled(true);
             }
         });
-        if (param.getValue() != null) {
-            input.setInputPasswordText(param.getValue());
-        } else {
-            input.setInputPasswordText("");
-        }
 
         if (param.getMin() != null && param.getMin().equals(param.getMax())) {
             input.setInputPasswordReadOnly(true);

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,7 +49,6 @@ import org.gwtbootstrap3.client.ui.TextArea;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.base.TextBoxBase;
 import org.gwtbootstrap3.client.ui.constants.IconType;
-import org.gwtbootstrap3.client.ui.constants.InputType;
 import org.gwtbootstrap3.client.ui.constants.Toggle;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.gwtbootstrap3.client.ui.form.error.BasicEditorError;
@@ -66,8 +65,10 @@ public abstract class AbstractServicesUi extends Composite {
 
     private static final String TARGET_SUFFIX = ".target";
 
-    protected static final Logger logger = Logger.getLogger(ServicesUi.class.getSimpleName());
+    protected static final Logger logger = Logger.getLogger(AbstractServicesUi.class.getSimpleName());
     protected static final Logger errorLogger = Logger.getLogger("ErrorLogger");
+
+    private static final String PLACEHOLDER = "Placeholder";
 
     protected static final Messages MSGS = GWT.create(Messages.class);
     protected static final LabelComparator<String> DROPDOWN_LABEL_COMPARATOR = new LabelComparator<>();
@@ -388,31 +389,40 @@ public abstract class AbstractServicesUi extends Composite {
             }
         }
 
-        final Input input = new Input();
-        input.setType(InputType.PASSWORD);
+        final NewPasswordInputForm input = new NewPasswordInputForm();
+        input.setInputPasswordText(param.getValue());
+        input.setShowPasswordButtonEnabled(!PLACEHOLDER.equals(input.getInputPasswordText()));
+        input.setInputPasswordClickHandler(handler -> {
+            if (input.isInputPasswordEnabled()
+                    && input.getInputPasswordText().equals(PLACEHOLDER)) {
+                input.setInputPasswordText("");
+                input.validateInputPassword();
+                input.setShowPasswordButtonEnabled(true);
+            }
+        });
         if (param.getValue() != null) {
-            input.setText(param.getValue());
+            input.setInputPasswordText(param.getValue());
         } else {
-            input.setText("");
+            input.setInputPasswordText("");
         }
 
         if (param.getMin() != null && param.getMin().equals(param.getMax())) {
-            input.setReadOnly(true);
-            input.setEnabled(false);
+            input.setInputPasswordReadOnly(true);
+            input.setInputPasswordEnabled(false);
         }
 
-        input.addValidator(new Validator() {
+        input.addInputPasswordValidator(new Validator() {
 
             @Override
             public List<EditorError> validate(Editor editor, Object value) {
 
                 List<EditorError> result = new ArrayList<>();
-                if ((input.getText() == null || "".equals(input.getText().trim())) && param.isRequired()) {
+                if ((input.getInputPasswordText() == null || "".equals(input.getInputPasswordText().trim())) && param.isRequired()) {
                     // null in required field
-                    result.add(new BasicEditorError(input, input.getText(), MSGS.formRequiredParameter()));
+                    result.add(new BasicEditorError(input, input.getInputPasswordText(), MSGS.formRequiredParameter()));
                     AbstractServicesUi.this.valid.put(param.getId(), false);
                 } else {
-                    param.setValue(input.getText());
+                    param.setValue(input.getInputPasswordText());
                     AbstractServicesUi.this.valid.put(param.getId(), true);
                 }
 
@@ -425,14 +435,14 @@ public abstract class AbstractServicesUi extends Composite {
             }
         });
 
-        input.addKeyUpHandler(event -> {
-            input.validate(true);
+        input.setInputPasswordKeyUpHandler(event -> {
+            input.validateInputPassword(true);
             setDirty(true);
         });
 
         formGroup.add(input);
 
-        input.validate(true);
+        input.validateInputPassword(true);
     }
 
     protected void renderBooleanField(final GwtConfigParameter param, boolean isFirstInstance, FormGroup formGroup) {

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/NewPasswordInputForm.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/NewPasswordInputForm.java
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.client.ui;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.kura.web.shared.model.GwtPasswordStrenghtRequirements;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.InputGroup;
+import org.gwtbootstrap3.client.ui.InputGroupButton;
+import org.gwtbootstrap3.client.ui.base.mixin.ErrorHandlerMixin;
+import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.gwtbootstrap3.client.ui.constants.InputType;
+import org.gwtbootstrap3.client.ui.form.validator.Validator;
+
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.editor.client.EditorError;
+import com.google.gwt.editor.client.HasEditorErrors;
+import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.event.dom.client.MouseOutHandler;
+import com.google.gwt.event.dom.client.MouseOverHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+public class NewPasswordInputForm extends InputGroup implements HasEditorErrors<String> {
+
+    private final ErrorHandlerMixin<String> errorHandlerMixin = new ErrorHandlerMixin<String>(this);
+
+    private final NewPasswordInput newPasswordInput;
+    private final Button showPasswordButton;
+    private final InputGroupButton showPasswordButtonGroup;
+
+    /* Constructor */
+    public NewPasswordInputForm() {
+        this.newPasswordInput = initializePasswordInput();
+        this.showPasswordButton = initializeShowPasswordButton();
+        this.showPasswordButtonGroup = initializeShowPasswordButtonGroup();
+        this.getElement().getStyle().setProperty("gap", "10px");
+        this.add(this.showPasswordButtonGroup);
+        this.add(this.newPasswordInput);
+    }
+
+    /* Items initialization */
+
+    private NewPasswordInput initializePasswordInput() {
+        NewPasswordInput input = new NewPasswordInput();
+        input.setAllowPlaceholder(true);
+        input.setType(InputType.PASSWORD);
+        input.setId("password");
+        input.setEnabled(true);
+        input.setVisible(true);
+        return input;
+    }
+
+    private Button initializeShowPasswordButton() {
+        Button button = new Button();
+        button.setIcon(IconType.EYE);
+        button.setEnabled(true);
+        button.setVisible(true);
+        button.setIconFixedWidth(true);
+        button.addClickHandler(handler -> {
+            if (this.isShowPasswordButtonEnabled()) {
+                if (this.getInputPasswordType().equals(InputType.PASSWORD)) {
+                    this.setInputPasswordType(InputType.TEXT);
+                    this.setShowPasswordButtonIcon(IconType.EYE_SLASH);
+                } else {
+                    this.setInputPasswordType(InputType.PASSWORD);
+                    this.setShowPasswordButtonIcon(IconType.EYE);
+                }
+            }
+        });
+        return button;
+    }
+
+    private InputGroupButton initializeShowPasswordButtonGroup() {
+        InputGroupButton groupButton = new InputGroupButton();
+        groupButton.add(this.showPasswordButton);
+        groupButton.getElement().getStyle().setPaddingRight(5, Unit.PX);
+        return groupButton;
+    }
+
+    /* Public Utils */
+    public boolean validateInputPassword() {
+        return this.newPasswordInput.validate();
+    }
+
+    public boolean validateInputPassword(boolean show) {
+        return this.newPasswordInput.validate(show);
+    }
+
+    public HandlerRegistration addChangeHandler(ChangeHandler handler) {
+        return addDomHandler(handler, ChangeEvent.getType());
+    }
+
+    /* Public Password Input Getters */
+    public String getInputPasswordText() {
+        return this.newPasswordInput.getText();
+    }
+
+    public InputType getInputPasswordType() {
+        return this.newPasswordInput.getType();
+    }
+
+    public boolean isInputPasswordEnabled() {
+        return this.newPasswordInput.isEnabled();
+    }
+
+    public boolean isInputPasswordVisible() {
+        return this.newPasswordInput.isVisible();
+    }
+
+    /* Public Show/Hide Password Button Getters */
+
+    public boolean isShowPasswordButtonEnabled() {
+        return this.showPasswordButton.isEnabled();
+    }
+
+    public boolean isShowPasswordButtonVisible() {
+        return this.showPasswordButton.isVisible();
+    }
+
+    /* Show/Hide Password Button Customization */
+    public void setShowPasswordButtonEnabled(boolean enabled) {
+        this.showPasswordButton.setEnabled(enabled);
+    }
+
+    public void setShowPasswordButtonVisible(boolean visible) {
+        this.showPasswordButton.setVisible(visible);
+    }
+
+    public void setShowPasswordButtonIcon(IconType icon) {
+        this.showPasswordButton.setIcon(icon);
+    }
+
+    public void setShowPasswordButtonMouseOverHandler(MouseOverHandler handler) {
+        this.showPasswordButton.addMouseOverHandler(handler);
+    }
+
+    /* Password Input Customization */
+    public void setInputPasswordValue(String value) {
+        this.newPasswordInput.setValue(value);
+    }
+
+    public void setInputPasswordText(String text) {
+        this.newPasswordInput.setText(text);
+    }
+
+    public void setInputPasswordType(InputType type) {
+        this.newPasswordInput.setType(type);
+    }
+
+    public void setInputPasswordEnabled(boolean enabled) {
+        this.newPasswordInput.setEnabled(enabled);
+    }
+
+    public void setInputPasswordVisible(boolean visible) {
+        this.newPasswordInput.setVisible(visible);
+    }
+
+    @SafeVarargs
+    public final void setInputPasswordValidators(final Validator<String>... validators) {
+        this.newPasswordInput.setValidators(validators);
+    }
+
+    public final void setInputPasswordValidatorsFrom(Optional<String> identityName,
+            GwtPasswordStrenghtRequirements userOptions) {
+        this.newPasswordInput.setValidatorsFrom(identityName, userOptions);
+    }
+
+    public void addInputPasswordValidator(Validator<String> validator) {
+        this.newPasswordInput.addValidator(validator);
+    }
+
+    public void setInputPasswordClickHandler(ClickHandler handler) {
+        this.newPasswordInput.addClickHandler(handler);
+    }
+
+    public void setInputPasswordMouseOverHandler(MouseOverHandler handler) {
+        this.newPasswordInput.addMouseOverHandler(handler);
+    }
+
+    public void setInputPasswordMouseOutHandler(MouseOutHandler handler) {
+        this.newPasswordInput.addMouseOutHandler(handler);
+    }
+
+    public void setInputPasswordChangeHandler(ChangeHandler handler) {
+        this.newPasswordInput.addChangeHandler(handler);
+    }
+
+    public void setInputPasswordKeyUpHandler(KeyUpHandler handler) {
+        this.newPasswordInput.addKeyUpHandler(handler);
+    }
+
+    public void setInputPasswordBlurHandler(BlurHandler handler) {
+        this.newPasswordInput.addBlurHandler(handler);
+    }
+
+    public void setInputPasswordAllowBlank(boolean allowBlank) {
+        this.newPasswordInput.setAllowBlank(allowBlank);
+    }
+
+    public void setInputPasswordReadOnly(boolean readOnly) {
+        this.newPasswordInput.setReadOnly(readOnly);
+    }
+
+    public void setInputPasswordFocus(boolean focus) {
+        this.newPasswordInput.setFocus(focus);
+    }
+
+    public void resetPasswordInput() {
+        this.newPasswordInput.reset();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void showErrors(List<EditorError> errors) {
+        errorHandlerMixin.showErrors(errors);
+    }
+}

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
@@ -226,7 +226,7 @@ public class Picker extends Composite implements HasId {
         private void pickNewPasswordInput() {
             final NewPasswordInputForm inputForm = initNewPasswordInput();
 
-            final State<U> localState = new State<>(inputForm, provider, validators, consumer,
+            final State<U> localState = new State<>(inputForm, this.provider, this.validators, this.consumer,
                     this.onCancel.orElse(() -> {
                     }));
 

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
@@ -122,7 +122,8 @@ public class Picker extends Composite implements HasId {
 
         private Optional<String> message = Optional.empty();
         private Optional<Runnable> onCancel = Optional.empty();
-        private Optional<Consumer<Input>> customizer = Optional.empty();
+        private Optional<Consumer<Input>> simpleInputCustomizer = Optional.empty();
+        private Optional<Consumer<NewPasswordInputForm>> newPasswordInputCustomizer = Optional.empty();
 
         public Builder(final Function<String, U> provider) {
             this.provider = provider;
@@ -154,20 +155,34 @@ public class Picker extends Composite implements HasId {
         }
 
         public Builder<U> setInputCustomizer(final Consumer<Input> customizer) {
-            this.customizer = Optional.of(customizer);
+            this.simpleInputCustomizer = Optional.of(customizer);
+            return this;
+        }
+
+        public Builder<U> setPasswordInputCustomizer(final Consumer<NewPasswordInputForm> customizer) {
+            this.newPasswordInputCustomizer = Optional.of(customizer);
             return this;
         }
 
         private Input initInput() {
             final Input result = new Input();
             result.addKeyUpHandler(e -> result.validate());
-            if (this.customizer.isPresent()) {
-                this.customizer.get().accept(result);
+            if (this.simpleInputCustomizer.isPresent()) {
+                this.simpleInputCustomizer.get().accept(result);
             }
             return result;
         }
 
-        public void pick() {
+        private NewPasswordInputForm initNewPasswordInput() {
+            final NewPasswordInputForm result = new NewPasswordInputForm();
+            result.setInputPasswordKeyUpHandler(e -> result.validateInputPassword());
+            if (this.newPasswordInputCustomizer.isPresent()) {
+                this.newPasswordInputCustomizer.get().accept(result);
+            }
+            return result;
+        }
+
+        public void pick(boolean isPasswordInput) {
             requireNonNull(this.provider, "provider cannot be null");
             requireNonNull(this.validators, "validators cannot be null");
             requireNonNull(this.consumer, "onPick cannot be null");
@@ -181,6 +196,16 @@ public class Picker extends Composite implements HasId {
                 Picker.this.label.setText("");
             }
 
+            if (isPasswordInput) {
+                pickNewPasswordInput();
+            } else {
+                pickInput();
+            }
+
+            Picker.this.modal.show();
+        }
+
+        private void pickInput() {
             final Input input = initInput();
 
             final State<U> localState = new State<>(input, this.provider, this.validators, this.consumer,
@@ -193,13 +218,28 @@ public class Picker extends Composite implements HasId {
             Picker.this.inputPanel.add(input);
 
             input.reset();
-            Picker.this.modal.show();
+        }
+
+        private void pickNewPasswordInput() {
+            final NewPasswordInputForm inputForm = initNewPasswordInput();
+
+            final State<U> localState = new State<>(inputForm, provider, validators, consumer,
+                    this.onCancel.orElse(() -> {
+                    }));
+
+            Picker.this.state = Optional.of(localState);
+            Picker.this.dismissAction = Optional.of(State::onCancel);
+
+            Picker.this.inputPanel.add(inputForm);
+
+            inputForm.resetPasswordInput();
         }
     }
 
     private class State<U> implements Validator<String> {
 
         private final Input value;
+        private final NewPasswordInputForm newPasswordValue;
         private final Function<String, U> provider;
         private final List<Validator<String>> validators;
         private final Consumer<U> consumer;
@@ -214,6 +254,7 @@ public class Picker extends Composite implements HasId {
                 Consumer<U> consumer,
                 final Runnable onCancel) {
             this.value = value;
+            this.newPasswordValue = null;
             this.provider = provider;
             this.validators = validators;
             this.consumer = consumer;
@@ -227,6 +268,26 @@ public class Picker extends Composite implements HasId {
                 }
             });
             this.shownHandler = Picker.this.modal.addShownHandler(e -> value.setFocus(true));
+        }
+
+        public State(NewPasswordInputForm value, Function<String, U> provider, List<Validator<String>> validators,
+                Consumer<U> consumer,
+                final Runnable onCancel) {
+            this.value = null;
+            this.newPasswordValue = value;
+            this.provider = provider;
+            this.validators = validators;
+            this.consumer = consumer;
+            this.onDismiss = onCancel;
+            this.newPasswordValue.setInputPasswordValidators(this);
+            this.submitHandler = Picker.this.form.addSubmitHandler(e -> {
+                e.cancel();
+                if (value.validateInputPassword()) {
+                    Picker.this.dismissAction = Optional.of(State::onAccept);
+                    Picker.this.modal.hide();
+                }
+            });
+            this.shownHandler = Picker.this.modal.addShownHandler(e -> newPasswordValue.setInputPasswordFocus(true));
         }
 
         public void onAccept() {

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
@@ -182,7 +182,7 @@ public class Picker extends Composite implements HasId {
             return result;
         }
 
-        public void pick(boolean isPasswordInput) {
+        public void pick(Class<?> inputType) {
             requireNonNull(this.provider, "provider cannot be null");
             requireNonNull(this.validators, "validators cannot be null");
             requireNonNull(this.consumer, "onPick cannot be null");
@@ -196,10 +196,13 @@ public class Picker extends Composite implements HasId {
                 Picker.this.label.setText("");
             }
 
-            if (isPasswordInput) {
+            if (inputType == NewPasswordInputForm.class) {
                 pickNewPasswordInput();
-            } else {
+            } else if (inputType == Input.class) {
                 pickInput();
+            } else {
+                throw new IllegalArgumentException("Supported input types are Input and NewPasswordInputForm, but was "
+                        + inputType.getName());
             }
 
             Picker.this.modal.show();

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1095,6 +1095,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                     && TabWirelessUi.this.passwordInputForm.getInputPasswordText().equals(PLACEHOLDER)) {
                 TabWirelessUi.this.passwordInputForm.setInputPasswordText("");
                 this.passwordInputForm.validateInputPassword();
+                this.passwordInputForm.setShowPasswordButtonEnabled(true);
             }
         });
 

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
 import org.eclipse.kura.system.SystemService;
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.EntryClassUi;
-import org.eclipse.kura.web.client.ui.NewPasswordInput;
+import org.eclipse.kura.web.client.ui.NewPasswordInputForm;
 import org.eclipse.kura.web.client.ui.validator.GwtValidators;
 import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.client.util.HelpButton;
@@ -244,7 +244,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     TextBox longI;
 
     @UiField
-    NewPasswordInput password;
+    NewPasswordInputForm passwordInputForm;
 
     @UiField
     TextBox rssi;
@@ -260,9 +260,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
     @UiField
     Button buttonSsid;
-
-    @UiField
-    Button buttonShowPassword;
 
     @UiField
     FormGroup groupRssi;
@@ -400,7 +397,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         }
     }
 
-    @UiHandler(value = { "wireless", "ssid", "radio", "security", "password", "pairwise", "group", "bgscan",
+    @UiHandler(value = { "wireless", "ssid", "radio", "security", "passwordInputForm", "pairwise", "group", "bgscan",
             "longI", "shortI", "radio1", "radio2", "radio3", "radio4", "rssi", "channelList", "countryCode" })
     public void onChange(ChangeEvent e) {
         setDirty(true);
@@ -560,7 +557,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             }
         }
 
-        this.password.setValue(this.activeConfig.getPassword());
+        this.passwordInputForm.setInputPasswordValue(this.activeConfig.getPassword());
 
         String activePairwiseCiphers = this.activeConfig.getPairwiseCiphers();
         if (activePairwiseCiphers != null) {
@@ -648,24 +645,24 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
         this.groupPassword.setValidationState(ValidationState.NONE);
         if (shouldPasswordItemBeEnabled) {
-            this.password.setType(InputType.PASSWORD);
-            this.buttonShowPassword.setIcon(IconType.EYE);
-            this.buttonShowPassword.setEnabled(!PLACEHOLDER.equals(TabWirelessUi.this.password.getText()));
-            this.buttonShowPassword.setVisible(true);
-            this.password.setEnabled(true);
-            this.password.setVisible(true);
+            this.passwordInputForm.setInputPasswordType(InputType.PASSWORD);
+            this.passwordInputForm.setShowPasswordButtonIcon(IconType.EYE);
+            this.passwordInputForm.setShowPasswordButtonEnabled(!PLACEHOLDER.equals(this.passwordInputForm.getInputPasswordText()));
+            this.passwordInputForm.setShowPasswordButtonVisible(true);
+            this.passwordInputForm.setInputPasswordEnabled(true);
+            this.passwordInputForm.setInputPasswordVisible(true);
             this.passwordHelp.setVisible(true);
             this.labelPassword.setVisible(true);
 
         } else {
-            this.password.setEnabled(false);
-            this.password.setVisible(false);
+            this.passwordInputForm.setInputPasswordEnabled(false);
+            this.passwordInputForm.setInputPasswordVisible(false);
             this.passwordHelp.setVisible(false);
             this.labelPassword.setVisible(false);
-            this.buttonShowPassword.setEnabled(false);
-            this.buttonShowPassword.setVisible(false);
+            this.passwordInputForm.setShowPasswordButtonEnabled(false);
+            this.passwordInputForm.setShowPasswordButtonVisible(false);
             // Clear password validators and errors when hidden
-            this.password.setValidators();
+            this.passwordInputForm.setInputPasswordValidators();
             this.helpPassword.setText("");
         }
     }
@@ -875,7 +872,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             }
         }
 
-        this.password.setText("");
+        this.passwordInputForm.setInputPasswordText("");
 
         for (int i = 0; i < this.pairwise.getItemCount(); i++) {
             if (this.pairwise.getItemText(i).equals(WIFI_CIPHERS_CCMP_TKIP_MESSAGE)) {
@@ -1075,48 +1072,36 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
     private void initPasswordItem() {
         this.labelPassword.setText(MSGS.netWifiWirelessPassword());
-        this.password.addMouseOverHandler(event -> {
-            if (TabWirelessUi.this.password.isEnabled()) {
+        this.passwordInputForm.setInputPasswordMouseOverHandler(handler -> {
+            if (TabWirelessUi.this.passwordInputForm.isInputPasswordEnabled()) {
                 TabWirelessUi.this.helpText.clear();
                 TabWirelessUi.this.helpText.add(new Span(MSGS.netWifiToolTipPassword()));
             }
         });
 
-        this.password.addBlurHandler(e -> this.password.validate());
-        this.password.setAllowBlank(true);
-        this.password.addMouseOutHandler(event -> resetHelp());
+        this.passwordInputForm.setInputPasswordBlurHandler(e -> this.passwordInputForm.validateInputPassword());
+        this.passwordInputForm.setInputPasswordAllowBlank(true);
+        this.passwordInputForm.setInputPasswordMouseOutHandler(event -> resetHelp());
 
-        this.password.addKeyUpHandler(event -> this.password.validate());
-        this.password.addChangeHandler(event -> {
+        this.passwordInputForm.setInputPasswordKeyUpHandler(event -> this.passwordInputForm.validateInputPassword());
+        this.passwordInputForm.setInputPasswordChangeHandler(handler -> {
             refreshForm();
             checkPassword();
         });
 
-        this.password.setType(InputType.PASSWORD);
-        this.password.addClickHandler(event -> {
-            if (TabWirelessUi.this.password.isEnabled()
-                    && TabWirelessUi.this.password.getText().equals(PLACEHOLDER)) {
-                TabWirelessUi.this.password.setText("");
-                this.password.validate();
+        this.passwordInputForm.setInputPasswordType(InputType.PASSWORD);
+        this.passwordInputForm.setInputPasswordClickHandler(handler -> {
+            if (TabWirelessUi.this.passwordInputForm.isInputPasswordEnabled()
+                    && TabWirelessUi.this.passwordInputForm.getInputPasswordText().equals(PLACEHOLDER)) {
+                TabWirelessUi.this.passwordInputForm.setInputPasswordText("");
+                this.passwordInputForm.validateInputPassword();
             }
         });
 
         // Show Password button
         updatePasswordItemVisibility();
 
-        this.buttonShowPassword.addClickHandler(event -> {
-            if (TabWirelessUi.this.buttonShowPassword.isEnabled()) {
-                if (this.password.getType().equals(InputType.PASSWORD)) {
-                    TabWirelessUi.this.password.setType(InputType.TEXT);
-                    TabWirelessUi.this.buttonShowPassword.setIcon(IconType.EYE_SLASH);
-                } else {
-                    TabWirelessUi.this.password.setType(InputType.PASSWORD);
-                    TabWirelessUi.this.buttonShowPassword.setIcon(IconType.EYE);
-                }
-            }
-        });
-
-        this.buttonShowPassword.addMouseOverHandler(event -> {
+        this.passwordInputForm.setShowPasswordButtonMouseOverHandler(event -> {
             TabWirelessUi.this.helpText.clear();
             TabWirelessUi.this.helpText.add(new Span(MSGS.netWifiToolTipShowButtonPassword()));
         });
@@ -1393,7 +1378,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
             if (getWirelessMode() != GwtWifiWirelessMode.netWifiWirelessModeAccessPoint) {
 
-                this.password.setValidators();
+                this.passwordInputForm.setInputPasswordValidators();
                 checkPassword();
                 return;
 
@@ -1401,24 +1386,23 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
             if (this.security != null && isWpaLikePairwiseSecurity()) {
 
-                this.password.setValidatorsFrom(Optional.empty(), passwordStrengthRequirements);
+                this.passwordInputForm.setInputPasswordValidatorsFrom(Optional.empty(), passwordStrengthRequirements);
                 passwordStrengthRequirements.setPasswordMinimumLength(
                         Math.min(passwordStrengthRequirements.getPasswordMinimumLength(), 63));
 
-                this.password
-                        .addValidator(
-                                GwtValidators.regex(REGEX_PASS_WPA, MSGS.netWifiWirelessInvalidWPAPassword()));
+                this.passwordInputForm.addInputPasswordValidator(
+                        GwtValidators.regex(REGEX_PASS_WPA, MSGS.netWifiWirelessInvalidWPAPassword()));
 
             } else if (this.security != null
                     && this.security.getSelectedItemText().equals(WIFI_SECURITY_WEP_MESSAGE)) {
 
-                this.password.setValidators();
-                this.password
-                        .addValidator(
+                this.passwordInputForm.setInputPasswordValidators();
+                this.passwordInputForm
+                        .addInputPasswordValidator(
                                 GwtValidators.regex(REGEX_PASS_WEP, MSGS.netWifiWirelessInvalidWEPPassword()));
             } else {
                 // Clears all validators when password is not required
-                this.password.setValidators();
+                this.passwordInputForm.setInputPasswordValidators();
             }
 
             checkPassword();
@@ -1754,7 +1738,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
         // Password
         if (this.groupPassword.getValidationState().equals(ValidationState.NONE)) {
-            gwtWifiConfig.setPassword(this.password.getText());
+            gwtWifiConfig.setPassword(this.passwordInputForm.getInputPasswordText());
         }
     }
 
@@ -1810,11 +1794,12 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     private boolean checkPassword() {
         boolean result = true;
 
-        if(this.password != null) {
+        if (this.passwordInputForm != null) {
             this.groupPassword.setValidationState(ValidationState.NONE);
         }
-        if (this.password != null && this.password.isVisible() && this.password.isEnabled()
-                && !this.password.validate()) {
+        if (this.passwordInputForm != null && this.passwordInputForm.isInputPasswordVisible()
+                && this.passwordInputForm.isInputPasswordEnabled()
+                && !this.passwordInputForm.validateInputPassword()) {
             this.groupPassword.setValidationState(ValidationState.ERROR);
             result = false;
         } else {

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1079,11 +1079,11 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             }
         });
 
-        this.passwordInputForm.setInputPasswordBlurHandler(e -> this.passwordInputForm.validateInputPassword());
+        this.passwordInputForm.setInputPasswordBlurHandler(handler -> this.passwordInputForm.validateInputPassword());
         this.passwordInputForm.setInputPasswordAllowBlank(true);
-        this.passwordInputForm.setInputPasswordMouseOutHandler(event -> resetHelp());
+        this.passwordInputForm.setInputPasswordMouseOutHandler(handler -> resetHelp());
 
-        this.passwordInputForm.setInputPasswordKeyUpHandler(event -> this.passwordInputForm.validateInputPassword());
+        this.passwordInputForm.setInputPasswordKeyUpHandler(handler -> this.passwordInputForm.validateInputPassword());
         this.passwordInputForm.setInputPasswordChangeHandler(handler -> {
             refreshForm();
             checkPassword();
@@ -1101,7 +1101,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         // Show Password button
         updatePasswordItemVisibility();
 
-        this.passwordInputForm.setShowPasswordButtonMouseOverHandler(event -> {
+        this.passwordInputForm.setShowPasswordButtonMouseOverHandler(handler -> {
             TabWirelessUi.this.helpText.clear();
             TabWirelessUi.this.helpText.add(new Span(MSGS.netWifiToolTipShowButtonPassword()));
         });

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.ui.xml
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2026 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.ui.xml
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.ui.xml
@@ -107,10 +107,8 @@
                                 <util:HelpButton ui:field="passwordHelp"/>
                                 <b:HelpBlock color="red"
                                     ui:field="helpPassword" />
-                                <kura:NewPasswordInput type="PASSWORD" b:id="password"
-                                    ui:field="password" allowPlaceholder="true"/>
-                                <b:Button ui:field="buttonShowPassword"
-                                        icon="EYE" iconFixedWidth="true" />
+                                <kura:NewPasswordInputForm b:id="passwordInputForm"
+                                    ui:field="passwordInputForm"/>
                             </b:FormGroup>
 
                             <b:FormGroup>

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -284,8 +284,7 @@ public class UserConfigUi extends Composite {
                             .setPasswordInputCustomizer(input -> input.setInputPasswordType(InputType.PASSWORD)) //
                             .setOnCancel(onDismiss) //
                             .setValidators(Collections.singletonList(GwtValidators
-                                    .predicate(
-                                            newPassword::equals, MSGS.usersPasswordMismatch()))) //
+                                    .predicate(newPassword::equals, MSGS.usersPasswordMismatch()))) //
                             .setOnPick(p -> {
                                 this.userData.setNewPassword(Optional.of(p));
                                 this.listener.onUserDataChanged(this.userData);

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
@@ -22,6 +22,7 @@ import org.eclipse.kura.web.client.configuration.HasConfiguration;
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.ConfigurableComponentUi;
 import org.eclipse.kura.web.client.ui.EntryClassUi;
+import org.eclipse.kura.web.client.ui.NewPasswordInputForm;
 import org.eclipse.kura.web.client.ui.Picker;
 import org.eclipse.kura.web.client.ui.drivers.assets.BooleanInputCell;
 import org.eclipse.kura.web.client.ui.validator.GwtValidators;
@@ -288,8 +289,8 @@ public class UserConfigUi extends Composite {
                             .setOnPick(p -> {
                                 this.userData.setNewPassword(Optional.of(p));
                                 this.listener.onUserDataChanged(this.userData);
-                            }).pick(true))
-                    .pick(true);
+                            }).pick(NewPasswordInputForm.class)) //
+                    .pick(NewPasswordInputForm.class);
         });
 
     }

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
@@ -274,22 +274,23 @@ public class UserConfigUi extends Composite {
             this.picker.builder() //
                     .setTitle(MSGS.usersSetPassword()) //
                     .setMessage(MSGS.usersDefineNewPassword()) //
-                    .setInputCustomizer(input -> input.setType(InputType.PASSWORD)) //
+                    .setPasswordInputCustomizer(input -> input.setInputPasswordType(InputType.PASSWORD)) //
                     .setOnCancel(onDismiss) //
                     .setValidators(GwtValidators.newPassword(Optional.of(this.userData.getUserName()), //
                             passwordStrengthRequirements)) //
                     .setOnPick(newPassword -> this.picker.builder() //
                             .setTitle(MSGS.usersConfirmPassword()) //
                             .setMessage(MSGS.usersRepeatPassword()) //
-                            .setInputCustomizer(input -> input.setType(InputType.PASSWORD)) //
+                            .setPasswordInputCustomizer(input -> input.setInputPasswordType(InputType.PASSWORD)) //
                             .setOnCancel(onDismiss) //
                             .setValidators(Collections.singletonList(GwtValidators
-                                    .predicate(confirm -> newPassword.equals(confirm), MSGS.usersPasswordMismatch()))) //
+                                    .predicate(
+                                            newPassword::equals, MSGS.usersPasswordMismatch()))) //
                             .setOnPick(p -> {
                                 this.userData.setNewPassword(Optional.of(p));
                                 this.listener.onUserDataChanged(this.userData);
-                            }).pick())
-                    .pick();
+                            }).pick(true))
+                    .pick(true);
         });
 
     }

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UsersPanelUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UsersPanelUi.java
@@ -177,7 +177,7 @@ public class UsersPanelUi extends Composite implements Tab, UserConfigUi.Listene
                                     this.dataProvider.getList().add(userConfig);
                                     setDirty(true);
                                 }))))))
-                .pick());
+                .pick(false));
 
         this.delete.addClickHandler(e -> this.alertDialog.show(MSGS.usersConfirmDeleteIdentity(), () -> {
             this.dataProvider.getList().remove(this.selectionModel.getSelectedObject());

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UsersPanelUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UsersPanelUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UsersPanelUi.java
+++ b/bundles/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UsersPanelUi.java
@@ -33,6 +33,7 @@ import org.eclipse.kura.web.shared.service.GwtSecurityTokenServiceAsync;
 import org.eclipse.kura.web.shared.service.GwtUserService;
 import org.eclipse.kura.web.shared.service.GwtUserServiceAsync;
 import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.Input;
 import org.gwtbootstrap3.client.ui.PanelFooter;
 import org.gwtbootstrap3.client.ui.Row;
 import org.gwtbootstrap3.client.ui.html.Paragraph;
@@ -177,7 +178,7 @@ public class UsersPanelUi extends Composite implements Tab, UserConfigUi.Listene
                                     this.dataProvider.getList().add(userConfig);
                                     setDirty(true);
                                 }))))))
-                .pick(false));
+                .pick(Input.class));
 
         this.delete.addClickHandler(e -> this.alertDialog.show(MSGS.usersConfirmDeleteIdentity(), () -> {
             this.dataProvider.getList().remove(this.selectionModel.getSelectedObject());


### PR DESCRIPTION
Following #23 , the show/hide button is a good improvement for the UX, so this PR introduces the feature in the entire framework.

The password input and the show/hide button are embedded in a single componente called `NewPasswordInputForm`: this object provides an input group containing the input password and an inputButton containing the show/hide button, along with some methods to customize the two items (handlers, visibility and so on).

Main changes:

- `TabWirelessUi` in wireless tab the wireless password now embeddes the input password and the button already present
- `AbstractServicesUi`: it's the generic class for the generation of component in the UI (services, factory and simple components, driver). The class gets the metatype and generates all the property: when dealing with passwords, the new object is used instead of the simple `Input`
- `Identities`: when a new user is created, or its password is changed, the new object is used instead of the simple Input. The class implementing the popup is `Picker` which is used both for the user name and the password. Therefore it was necessary to duplicate some method (gwt is a very good tool, indeed `InputGroup` is not an extension of `Input`, thus I didn't find a way to use a generic class to avoid duplication). This class is then used in `UserConfigUi` for the password and in `UserPanelUi` for the simple name