### PR TITLE
fix: Added missing net dependencies

### DIFF
--- a/target-definition/kura-management-ui.target.target
+++ b/target-definition/kura-management-ui.target.target
@@ -38,6 +38,18 @@
                 </dependency>
                 <dependency>
                     <groupId>org.eclipse.kura</groupId>
+                    <artifactId>org.eclipse.kura.core.net</artifactId>
+                    <version>3.0.0-SNAPSHOT</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.eclipse.kura</groupId>
+                    <artifactId>org.eclipse.kura.net.configuration</artifactId>
+                    <version>3.0.0-SNAPSHOT</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.eclipse.kura</groupId>
                     <artifactId>org.eclipse.kura.linux.net</artifactId>
                     <version>3.0.0-SNAPSHOT</version>
                     <type>jar</type>


### PR DESCRIPTION
This pull request adds two new dependencies to the `kura-management-ui.target.target` file, both from the `org.eclipse.kura` project. These dependencies are likely required for new or updated network-related features in the management UI.

Dependency updates:

* Added `org.eclipse.kura.core.net` version `3.0.0-SNAPSHOT` as a dependency.
* Added `org.eclipse.kura.net.configuration` version `3.0.0-SNAPSHOT` as a dependency.